### PR TITLE
MPV does not accept --disable-mruby

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1740,7 +1740,7 @@ if [[ $mpv != "n" ]] && pc_exists libavcodec libavformat libswscale libavfilter;
 
         mpv_enabled mruby &&
             { git merge --no-edit --no-gpg-sign origin/mruby ||
-              git merge --abort && mpv_disable mruby; }
+              git merge --abort && do_removeOption MPV_OPTS "--enable-mruby"; }
 
         files_exist libavutil.a && MPV_OPTS+=(--enable-static-build)
         CFLAGS+=" ${mpv_cflags[*]}" LDFLAGS+=" ${mpv_ldflags[*]}" \


### PR DESCRIPTION
When the merge with mruby fails, the current code adds the option "--disable-mruby" to the MPV_OPTS.
This breaks the MPV configuration with the error : --disable-mruby unknown option.
This commit will remove the option --enable-mruby from the array MPV_OPTS