### PR TITLE
Avoid mixing up ffmpeg_opts for 32bit build and 64 bit build

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -775,6 +775,7 @@ do_getFFmpegConfig() {
         fi
     fi
 
+    FFMPEG_OPTS=()
     for opt in "${FFMPEG_BASE_OPTS[@]}" "${FFMPEG_DEFAULT_OPTS[@]}"; do
         [[ -n $opt ]] && FFMPEG_OPTS+=("$opt")
     done


### PR DESCRIPTION
Avoid mixing up ffmpeg_opts for 32bit build and 64 bit build.
When starting the 64bit build, the arrray FFMPEG_OPTS still contains the options from the 32bit build.

